### PR TITLE
Use underscores in setup.cfg to fix warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file=README.rst
+description_file=README.rst
 
 [yapf]
 based_on_style=facebook


### PR DESCRIPTION
Use underscore instead of hyphen to fix the following warning:

    /usr/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead